### PR TITLE
chore: use ubuntu:20.04 docker to build doxygen because of GLibc version

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -13,17 +13,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-14]
+    container: ${{ matrix.os == 'ubuntu-22.04' && 'ubuntu:20.04' || matrix.os == 'ubuntu-22.04-arm' && 'arm64v8/ubuntu:20.04' || '' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Install Dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake flex bison
+          apt-get update
+          apt-get install -y build-essential cmake flex bison curl tar make python3
+        env:
+          DEBIAN_FRONTEND: noninteractive
       - name: Install Dependencies (macOS)
         if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
         run: |


### PR DESCRIPTION
chore: use ubuntu:20.04 docker to build doxygen because of GLibc version